### PR TITLE
Feature/fedn 256

### DIFF
--- a/mnist-keras/README.md
+++ b/mnist-keras/README.md
@@ -50,7 +50,7 @@ To start 2 clients:
 docker-compose -f docker-compose.yaml -f private-network.yaml up 
 ```
 
-> If you are connecting to a Reducer part of a distributed setup or in Studio, you should omit 'private-network.yaml'. 
+> If you are connecting to a Reducer with a distributed setup or in Studio, you should omit 'private-network.yaml'. 
 
 ### Start training 
 When clients are running, navigate to the 'Control' page of the Reducer to start the training. 

--- a/mnist-keras/README.md
+++ b/mnist-keras/README.md
@@ -14,7 +14,12 @@ Navigate to 'https://localhost:8090' (or the url of your Reducer) and follow ins
 To simulate the scenario of each client using a unique dataset we will make partitions in 'data/clients' of the complete dataset in 'data/mnist.npz'. The python script below will create 10 partitions:
 
 ``` bash
-python create_data_partitions.py 
+python create_data_partitions.py
+```
+Alternativly, create the disired number of partitions (e.g. 5):
+
+``` bash
+python create_data_partitions.py 5
 ```
 
 ## Attaching a client to the federation

--- a/mnist-keras/README.md
+++ b/mnist-keras/README.md
@@ -3,11 +3,19 @@ This classic example of hand-written text recognition is well suited both as a l
 
 > Note that this example shows how to configure FEDn for training, and how to configure and start clients. We assume that a FEDn network is aleady up and running with a blank, unconfigured Reducer. If this is not the case, start here: https://github.com/scaleoutsystems/fedn/blob/master/README.md
 
-### Local training and test data
-This example ships with the mnist dataset from https://s3.amazonaws.com/img-datasets/mnist.npz in 'data/mnist.npz'. 
+## Local training and test data
+This example ships with the mnist dataset from https://s3.amazonaws.com/img-datasets/mnist.npz in 'data/mnist.npz'.
+This dataset will be partitioned to simulate unique datasets for each client. 
 
 ## Configuring the Reducer  
-Navigate to 'https://localhost:8090' (or the url of your Reducer) and follow instructions to upload the compute package in 'package/package.tar.gz' and the initial model in 'initial_model/initial_model.npz'. 
+Navigate to 'https://localhost:8090' (or the url of your Reducer) and follow instructions to upload the compute package in 'package/package.tar.gz' and the initial model in 'initial_model/initial_model.npz'.
+
+## Create partitions
+To simulate the scenario of each client using a unique dataset we will make partitions in 'data/clients' of the complete dataset in 'data/mnist.npz'. The python script below will create 10 partitions:
+
+``` bash
+python create_data_partitions.py 
+```
 
 ## Attaching a client to the federation
 
@@ -17,7 +25,7 @@ Navigate to 'https://localhost:8090' (or the url of your Reducer) and follow ins
     - docker-compose
     - [Native client (OSX/Linux)](https://github.com/scaleoutsystems/examples/tree/main/how-tos/start-native-fedn-client)
 
-#### Docker
+### Docker
 1. Build the image
 
 ``` bash
@@ -26,16 +34,17 @@ docker build . -t mnist-client:latest
 
 2. Start a client (edit the path of the volume mounts to provide the absolute path to your local folder.)
 ```
-docker run -v /absolute-path-to-this-folder/data/:/app/data:ro -v /absolute-path-to-this-folder/client.yaml:/app/client.yaml --network fedn_default mnist-client fedn run client -in client.yaml 
+docker run -v /absolute-path-to-this-folder/data/clients/0:/app/data:ro -v /absolute-path-to-this-folder/client.yaml:/app/client.yaml --network fedn_default mnist-client fedn run client -in client.yaml --name client0
 ```
-(Repeat above steps as needed to deploy additional clients).
+(Repeat above steps as needed to deploy additional clients but change the data partition (e.g. .../clients/1) and the --name).
 
-#### docker-compose
+### docker-compose
 To start 2 clients: 
 
 ```bash
-docker-compose -f docker-compose.yaml -f private-network.yaml up --scale client=2 
+docker-compose -f docker-compose.yaml -f private-network.yaml up 
 ```
+
 > If you are connecting to a Reducer part of a distributed setup or in Studio, you should omit 'private-network.yaml'. 
 
 ### Start training 
@@ -45,10 +54,6 @@ When clients are running, navigate to the 'Control' page of the Reducer to start
 We have made it possible to configure a couple of settings to vary the conditions for the training. These configurations are expsosed in the file 'settings.yaml': 
 
 ```yaml 
-# Number of training samples used by each client
-training_samples: 600
-# Number of test samples used by each client (validation)
-test_samples: 100
 # How much to bias the client data samples towards certain classes (non-IID data partitions)
 bias: 0.7
 # Parameters for local training
@@ -70,8 +75,15 @@ For an explaination of the compute package structure and content: https://github
 The baseline CNN is specified in the file 'client/init_model.py'. This script creates an untrained neural network and serializes that to a file.  If you wish to alter the initial model, edit 'init_model.py' and 'models/mnist_model.py' then regenerate the initial model file (install dependencies as needed, see requirements.txt):
 
 ```bash
-python init_model.py 
+python init_model.py
 ```
+
+## When you are done
+ Don't forget to tear down docker-compose resources, e.g.:
+ ```bash
+docker-compose -f docker-compose.yaml -f private-network.yaml down
+ ```
+
 
 ## License
 Apache-2.0 (see LICENSE file for full information).

--- a/mnist-keras/client/data/read_data.py
+++ b/mnist-keras/client/data/read_data.py
@@ -1,13 +1,10 @@
 import numpy as np
-import os
 import tensorflow as tf
-from sklearn.model_selection import train_test_split
-from tensorflow import keras
 
-def read_data(path, nr_examples=1000,trainset=True):
+def read_data(path, trainset=True):
     """ Helper function to read and preprocess data for training with Keras. """
 
-    pack = np.load(path)
+    pack = np.load(path, allow_pickle=True)
 
     if trainset:
         X = pack['x_train']
@@ -16,20 +13,8 @@ def read_data(path, nr_examples=1000,trainset=True):
         X = pack['x_test']
         y = pack['y_test']
 
-    print("X shape: ", X.shape, ", y shape: ", y.shape)
-
-    sample_fraction = float(nr_examples)/len(y)
-
-    # The entire dataset is 60k images, we can subsample here for quicker testing.
-    if sample_fraction < 1.0:
-        _, X, _, y = train_test_split(X, y, test_size=sample_fraction)
     classes = range(10)
 
-    # Input image dimensions
-    img_rows, img_cols = 28, 28
-
-    ## The data, split between train and test sets
-    #X = X.reshape(X.shape[0], img_rows, img_cols, 1)
     X = X.astype('float32')
     X = np.expand_dims(X,-1)
     X /= 255

--- a/mnist-keras/client/data/read_data.py
+++ b/mnist-keras/client/data/read_data.py
@@ -19,4 +19,4 @@ def read_data(path, trainset=True):
     X = np.expand_dims(X,-1)
     X /= 255
     y = tf.keras.utils.to_categorical(y, len(classes))
-    return  (X, y, classes)
+    return  (X, y)

--- a/mnist-keras/client/data/read_data.py
+++ b/mnist-keras/client/data/read_data.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 def read_data(path, trainset=True):
     """ Helper function to read and preprocess data for training with Keras. """
 
-    pack = np.load(path, allow_pickle=True)
+    pack = np.load(path)
 
     if trainset:
         X = pack['x_train']

--- a/mnist-keras/client/settings.yaml
+++ b/mnist-keras/client/settings.yaml
@@ -1,7 +1,3 @@
-# Number of training samples used by each client
-training_samples: 600
-# Number of test samples used by each client (validation)
-test_samples: 100
 # How much to bias the client data samples towards certain classes (non-IID data partitions)
 bias: 0.7
 # Parameters for local training

--- a/mnist-keras/client/train.py
+++ b/mnist-keras/client/train.py
@@ -15,8 +15,8 @@ def train(model,data,settings):
     # We are caching the partition in the container home dir so that
     # the same training subset is used for each iteration for a client.
     try:
-        x_train = np.load('/tmp/local_dataset/x_train.npz', allow_pickle=True)
-        y_train = np.load('/tmp/local_dataset/y_train.npz', allow_pickle=True)
+        x_train = np.load('/tmp/local_dataset/x_train.npz')
+        y_train = np.load('/tmp/local_dataset/y_train.npz')
     except:
         (x_train, y_train, classes) = read_data(data,
                                                 trainset=True)

--- a/mnist-keras/client/train.py
+++ b/mnist-keras/client/train.py
@@ -1,10 +1,7 @@
 from __future__ import print_function
 import sys
 import tensorflow as tf
-import tensorflow.keras as keras
-import tensorflow.keras.models as krm
 import numpy as np
-import pickle
 import yaml
 tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 
@@ -18,11 +15,10 @@ def train(model,data,settings):
     # We are caching the partition in the container home dir so that
     # the same training subset is used for each iteration for a client.
     try:
-        x_train = np.load('/tmp/local_dataset/x_train.npz')
-        y_train = np.load('/tmp/local_dataset/y_train.npz')
+        x_train = np.load('/tmp/local_dataset/x_train.npz', allow_pickle=True)
+        y_train = np.load('/tmp/local_dataset/y_train.npz', allow_pickle=True)
     except:
         (x_train, y_train, classes) = read_data(data,
-                                                nr_examples=settings['training_samples'],
                                                 trainset=True)
 
         try:

--- a/mnist-keras/client/train.py
+++ b/mnist-keras/client/train.py
@@ -18,8 +18,7 @@ def train(model,data,settings):
         x_train = np.load('/tmp/local_dataset/x_train.npz')
         y_train = np.load('/tmp/local_dataset/y_train.npz')
     except:
-        (x_train, y_train, classes) = read_data(data,
-                                                trainset=True)
+        (x_train, y_train) = read_data(data, trainset=True)
 
         try:
             os.mkdir('/tmp/local_dataset')

--- a/mnist-keras/client/validate.py
+++ b/mnist-keras/client/validate.py
@@ -8,7 +8,7 @@ import os
 import yaml
 import numpy as np
 
-def validate(model,data,settings):
+def validate(model,data):
     print("-- RUNNING VALIDATION --", flush=True)
 
     # The data, split between train and test sets. We are caching the partition in
@@ -21,7 +21,7 @@ def validate(model,data,settings):
         x_train = np.load('/tmp/local_dataset/x_train.npz')
         y_train = np.load('/tmp/local_dataset/y_train.npz')
     except:
-        (x_train, y_train, classes) = read_data(data, trainset=True)
+        (x_train, y_train) = read_data(data, trainset=True)
         try:
             os.mkdir('/tmp/local_dataset')
             np.save('/tmp/local_dataset/x_train.npz', x_train)
@@ -35,7 +35,7 @@ def validate(model,data,settings):
         x_test = np.load('/tmp/local_dataset/x_test.npz')
         y_test = np.load('/tmp/local_dataset/y_test.npz')
     except:
-        (x_test, y_test, classes) = read_data(data, trainset=False)
+        (x_test, y_test) = read_data(data, trainset=False)
         try:
             os.mkdir('/tmp/local_dataset')
             np.save('/tmp/local_dataset/x_test.npz', x_test)
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     model = create_seed_model()
     model.set_weights(weights)
 
-    report = validate(model,'../data/mnist.npz',settings)
+    report = validate(model,'../data/mnist.npz')
 
     with open(sys.argv[2],"w") as fh:
         fh.write(json.dumps(report))

--- a/mnist-keras/client/validate.py
+++ b/mnist-keras/client/validate.py
@@ -2,7 +2,6 @@ import sys
 import tensorflow as tf
 tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 from data.read_data import read_data
-import pickle
 import json
 from sklearn import metrics
 import os
@@ -19,12 +18,10 @@ def validate(model,data,settings):
 
     # Training error (Client validates global model on same data as it trains on.)
     try:
-        x_train = np.load('/tmp/local_dataset/x_train.npz')
-        y_train = np.load('/tmp/local_dataset/y_train.npz')
+        x_train = np.load('/tmp/local_dataset/x_train.npz', allow_pickle=True)
+        y_train = np.load('/tmp/local_dataset/y_train.npz', allow_pickle=True)
     except:
-        (x_train, y_train, classes) = read_data(data,
-                                                nr_examples=settings['training_samples'],
-                                                trainset=True)
+        (x_train, y_train, classes) = read_data(data, trainset=True)
         try:
             os.mkdir('/tmp/local_dataset')
             np.save('/tmp/local_dataset/x_train.npz', x_train)
@@ -35,12 +32,10 @@ def validate(model,data,settings):
 
     # Test error (Client has a small dataset set aside for validation)
     try:
-        x_test = np.load('/tmp/local_dataset/x_test.npz')
-        y_test = np.load('/tmp/local_dataset/y_test.npz')
+        x_test = np.load('/tmp/local_dataset/x_test.npz', allow_pickle=True)
+        y_test = np.load('/tmp/local_dataset/y_test.npz', allow_pickle=True)
     except:
-        (x_test, y_test, classes) = read_data(data,
-                                                nr_examples=settings['test_samples'],
-                                                trainset=False)
+        (x_test, y_test, classes) = read_data(data, trainset=False)
         try:
             os.mkdir('/tmp/local_dataset')
             np.save('/tmp/local_dataset/x_test.npz', x_test)

--- a/mnist-keras/client/validate.py
+++ b/mnist-keras/client/validate.py
@@ -18,8 +18,8 @@ def validate(model,data,settings):
 
     # Training error (Client validates global model on same data as it trains on.)
     try:
-        x_train = np.load('/tmp/local_dataset/x_train.npz', allow_pickle=True)
-        y_train = np.load('/tmp/local_dataset/y_train.npz', allow_pickle=True)
+        x_train = np.load('/tmp/local_dataset/x_train.npz')
+        y_train = np.load('/tmp/local_dataset/y_train.npz')
     except:
         (x_train, y_train, classes) = read_data(data, trainset=True)
         try:
@@ -32,8 +32,8 @@ def validate(model,data,settings):
 
     # Test error (Client has a small dataset set aside for validation)
     try:
-        x_test = np.load('/tmp/local_dataset/x_test.npz', allow_pickle=True)
-        y_test = np.load('/tmp/local_dataset/y_test.npz', allow_pickle=True)
+        x_test = np.load('/tmp/local_dataset/x_test.npz')
+        y_test = np.load('/tmp/local_dataset/y_test.npz')
     except:
         (x_test, y_test, classes) = read_data(data, trainset=False)
         try:

--- a/mnist-keras/create_data_partitions.py
+++ b/mnist-keras/create_data_partitions.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import numpy as np
+from math import floor
+
+def splitset(dataset, parts):
+    """Partition data into "parts" partitions"""
+    n = dataset.shape[0]
+    local_n = floor(n/parts)
+    result = []
+    for i in range(parts):
+        result.append(dataset[i*local_n: (i+1)*local_n])
+    return result
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) < 2:
+        nr_of_datasets = 10
+    else:
+        nr_of_datasets = sys.argv[1]
+
+    package = np.load("data/mnist.npz")
+    data = {}
+    for key, val in package.items():
+        data[key] = splitset(val, nr_of_datasets)
+
+    if not os.path.exists('data/clients'):
+        os.mkdir('data/clients')
+
+    for i in range(nr_of_datasets):
+        if not os.path.exists('data/clients/{}'.format(str(i))):
+            os.mkdir('data/clients/{}'.format(str(i)))
+        np.savez('data/clients/{}'.format(str(i)) + '/mnist.npz',
+                x_train=data['x_train'][i],
+                y_train=data['y_train'][i],
+                x_test=data['x_test'][i],
+                y_test=data['y_test'][i])

--- a/mnist-keras/create_data_partitions.py
+++ b/mnist-keras/create_data_partitions.py
@@ -18,13 +18,14 @@ if __name__ == '__main__':
     if len(sys.argv) < 2:
         nr_of_datasets = 10
     else:
-        nr_of_datasets = sys.argv[1]
+        nr_of_datasets = int(sys.argv[1])
 
     package = np.load("data/mnist.npz")
     data = {}
     for key, val in package.items():
         data[key] = splitset(val, nr_of_datasets)
 
+    print("CREATING {} PARTITIONS INSIDE {}/data/clients".format(nr_of_datasets, os.getcwd()))
     if not os.path.exists('data/clients'):
         os.mkdir('data/clients')
 
@@ -36,3 +37,4 @@ if __name__ == '__main__':
                 y_train=data['y_train'][i],
                 x_test=data['x_test'][i],
                 y_test=data['y_test'][i])
+    print("DONE")

--- a/mnist-keras/create_data_partitions.py
+++ b/mnist-keras/create_data_partitions.py
@@ -10,7 +10,7 @@ def splitset(dataset, parts):
     result = []
     for i in range(parts):
         result.append(dataset[i*local_n: (i+1)*local_n])
-    return result
+    return np.array(result)
 
 
 if __name__ == '__main__':

--- a/mnist-keras/docker-compose.yaml
+++ b/mnist-keras/docker-compose.yaml
@@ -1,13 +1,24 @@
 version: '3.3'
 services:
-  client:
+  client0:
     environment:
       - GET_HOSTS_FROM=dns
-    image: "mnist-client-keras:latest"
+    image: "mnist-client:latest"
     build:
       context: .
     working_dir: /app
     command: /bin/bash -c "fedn run client -in client.yaml"
     volumes:
-      - ./data:/app/data:ro #mount as READ ONLY
+      - ./data/clients/0:/app/data:ro #mount as READ ONLY
+      - ./client.yaml:/app/client.yaml
+  client1:
+    environment:
+      - GET_HOSTS_FROM=dns
+    image: "mnist-client:latest"
+    build:
+      context: .
+    working_dir: /app
+    command: /bin/bash -c "fedn run client -in client.yaml"
+    volumes:
+      - ./data/clients/1:/app/data:ro #mount as READ ONLY
       - ./client.yaml:/app/client.yaml


### PR DESCRIPTION
mnist-keras example has been updated with data partitions

Summery:
* create_data_partitions.py to split mnist.npz into N partitions inside data/clients
* Settings for training_samples and test_samples has been removed in settings.yaml and train.py ,validate.py and read_data.py have been updated accordingly.
* docker-compose.yaml for deployment of two clients has been updated to support different data partitions, i.e two containers are created with different volume mounts (--scale removed) 
* README has been updated with the new changes

Comments:
Tested with docker-compose setup for FEDn(develop) using three clients