### PR TITLE
pin tf 2.7.0

### DIFF
--- a/mnist-keras/requirements.txt
+++ b/mnist-keras/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow>=2.3.2
+tensorflow==2.7.0
 pandas
 sklearn


### PR DESCRIPTION
example is currently not working with the latest tensorflow (2.8.0) so I pinned to latest working version (2.7.0)